### PR TITLE
Remove v prefix on version numbers

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -9,6 +9,7 @@ import (
 var regexpSigns = regexp.MustCompile(`[_\-+]`)
 var regexpDotBeforeDigit = regexp.MustCompile(`([^.\d]+)`)
 var regexpMultipleDots = regexp.MustCompile(`\.{2,}`)
+var regexpVersionV = regexp.MustCompile(`^v\d`)
 
 var specialForms = map[string]int{
 	"dev":   -6,
@@ -24,13 +25,13 @@ var specialForms = map[string]int{
 }
 
 // Compares two normalizated version number strings, for a particular relationship
-// 
-// The function first replaces _, - and + with a dot . in the version strings 
-// and also inserts dots . before and after any non number so that for example 
-// '4.3.2RC1' becomes '4.3.2.RC.1'. 
-// 
+//
+// The function first replaces _, - and + with a dot . in the version strings
+// and also inserts dots . before and after any non number so that for example
+// '4.3.2RC1' becomes '4.3.2.RC.1'.
+//
 // Then it splits the results like if you were using Split(version, '.').
-// Then it compares the parts starting from left to right. If a part contains 
+// Then it compares the parts starting from left to right. If a part contains
 // special version strings these are handled in the following order: any string
 // not found in this list:
 //   < dev < alpha = a < beta = b < RC = rc < # < pl = p.
@@ -118,6 +119,10 @@ func CompareSimple(version1, version2 string) int {
 func prepVersion(version string) []string {
 	if len(version) == 0 {
 		return []string{""}
+	}
+
+	if regexpVersionV.MatchString(version) {
+		version = version[1:]
 	}
 
 	version = regexpSigns.ReplaceAllString(version, ".")

--- a/compare_test.go
+++ b/compare_test.go
@@ -798,6 +798,7 @@ var compareVersionValues = map[string]bool{
 	"1.0pl1 <> 1.0pl1":      false,
 	"1.0pl1 != 1.0pl1":      false,
 	"2.2.3.0 < 2.4.0.0-dev": true,
+	"2.3.4 < v3.1.2":        true,
 }
 
 func TestCompareVersion(t *testing.T) {


### PR DESCRIPTION
This removes the v prefix some folk put on their version numbers. So now 2.0.1 is declared as < v3.0.1.
