### PR TITLE
Fix memory leak and speed up.

### DIFF
--- a/constraint_test.go
+++ b/constraint_test.go
@@ -36,7 +36,7 @@ func TestMatchSuccess(t *testing.T) {
 	out := true
 
 	if x := constraint.Match("1.0"); x != out {
-		t.Errorf("FAIL: Match() = {%s}: want {%s}", x, out)
+		t.Errorf("FAIL: Match() = {%v}: want {%v}", x, out)
 	}
 }
 
@@ -45,6 +45,6 @@ func TestMatchFail(t *testing.T) {
 	out := false
 
 	if x := constraint.Match("2.0"); x != out {
-		t.Errorf("FAIL: Match() = {%s}: want {%s}", x, out)
+		t.Errorf("FAIL: Match() = {%v}: want {%v}", x, out)
 	}
 }

--- a/group_test.go
+++ b/group_test.go
@@ -134,7 +134,7 @@ func TestMatch(t *testing.T) {
 
 		constraint := NewConstrainGroupFromString(tmp[0])
 		if x := constraint.Match(tmp[1]); x != out {
-			t.Errorf("FAIL: Match(%v) = {%s}: want {%s}", in, x, out)
+			t.Errorf("FAIL: Match(%v) = {%v}: want {%v}", in, x, out)
 		}
 	}
 }


### PR DESCRIPTION
DO NOT create new regex expression every time when the pattern has been compiled so many times.

I've made a cache for `*regexp.Regexp`. 
In most cases, MustCompile would hit cache, which could speed up the process.

----

PS:
I use go-version heavily in my project.
Golang's `pprof` told me that "xxx.xxx.xxx/xxx/vendor/github.com/mcuadros/go-version.RegFind (75289.45MB)"
That's Horrible.🤒