### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/compare.go
+++ b/compare.go
@@ -27,7 +27,7 @@ var specialForms = map[string]int{
 
 var unknownForm int = -7
 
-// Compares two version number strings, for a particular relationship
+// Compare compares two version number strings, for a particular relationship
 //
 // Usage
 //     version.Compare("2.3.4", "v3.1.2", "<")
@@ -42,7 +42,7 @@ func Compare(version1, version2, operator string) bool {
 	return CompareNormalized(version1N, version2N, operator)
 }
 
-// Compares two normalizated version number strings, for a particular relationship
+// CompareNormalized compares two normalizated version number strings, for a particular relationship
 //
 // The function first replaces _, - and + with a dot . in the version strings
 // and also inserts dots . before and after any non number so that for example
@@ -84,7 +84,7 @@ func CompareNormalized(version1, version2, operator string) bool {
 	return false
 }
 
-// Compares two normalizated version number strings
+// CompareSimple compares two normalizated version number strings
 //
 // Just the same of CompareVersion but return a int result, 0 if both version
 // are equal, 1 if the right side is bigger and -1 if the right side is lower

--- a/constraint.go
+++ b/constraint.go
@@ -9,7 +9,7 @@ type Constraint struct {
 	version  string
 }
 
-// Return a new Constrain and sets operator and version to compare
+// NewConstrain returns a new Constrain and sets operator and version to compare
 func NewConstrain(operator, version string) *Constraint {
 	constraint := new(Constraint)
 	constraint.SetOperator(operator)
@@ -23,7 +23,7 @@ func (self *Constraint) SetOperator(operator string) {
 	self.operator = operator
 }
 
-// Get operator to compare
+// GetOperator gets operator to compare
 func (self *Constraint) GetOperator() string {
 	return self.operator
 }
@@ -33,7 +33,7 @@ func (self *Constraint) SetVersion(version string) {
 	self.version = version
 }
 
-// Get version to compare
+// GetVersion gets version to compare
 func (self *Constraint) GetVersion() string {
 	return self.version
 }
@@ -43,7 +43,7 @@ func (self *Constraint) Match(version string) bool {
 	return Compare(version, self.version, self.operator)
 }
 
-// Return a string representation
+// String returns a string representation
 func (self *Constraint) String() string {
 	return strings.Trim(self.operator+" "+self.version, " ")
 }

--- a/group.go
+++ b/group.go
@@ -11,14 +11,14 @@ type ConstraintGroup struct {
 	constraints []*Constraint
 }
 
-// Return a new NewConstrainGroup
+// NewConstrainGroup returns a new NewConstrainGroup
 func NewConstrainGroup() *ConstraintGroup {
 	group := new(ConstraintGroup)
 
 	return group
 }
 
-// Return a new NewConstrainGroup and create the constraints based on a string
+// NewConstrainGroupFromString returns a new NewConstrainGroup and create the constraints based on a string
 //
 // Version constraints can be specified in a few different ways:
 //
@@ -55,7 +55,7 @@ func NewConstrainGroupFromString(name string) *ConstraintGroup {
 	return group
 }
 
-// Adds a Contraint to the group
+// AddConstraint adds a Contraint to the group
 func (self *ConstraintGroup) AddConstraint(constraint ...*Constraint) {
 	if self.constraints == nil {
 		self.constraints = make([]*Constraint, 0)
@@ -64,7 +64,7 @@ func (self *ConstraintGroup) AddConstraint(constraint ...*Constraint) {
 	self.constraints = append(self.constraints, constraint...)
 }
 
-// Return all the constraints
+// GetConstraints returns all the constraints
 func (self *ConstraintGroup) GetConstraints() []*Constraint {
 	return self.constraints
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?